### PR TITLE
Don't split arguments containing spaces

### DIFF
--- a/src/tmperamental.in
+++ b/src/tmperamental.in
@@ -4,4 +4,4 @@ TMPDIR=${TMPDIR:-$HOME/tmp}
 export TMPDIR
 LD_PRELOAD="${LD_PRELOAD} @pkglibdir@/libtmperamental.so"
 export LD_PRELOAD
-exec $@
+exec "$@"


### PR DESCRIPTION
Fixes: https://bugs.debian.org/862165